### PR TITLE
Füge einen Button hinzu um den IT-Support leicht kontaktieren zu können

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,14 +283,18 @@
         
       </div>
     </div>
+    <button id="btnSupport" class="btn btn-lg btn-info">IT-Support kon­tak­tie­ren</button>
     <script>
+      function _load_js(path, id) {
+        var elem = document.createElement("script");
+        elem.src = path;
+        elem.id = id;
+        document.body.appendChild(elem);
+        return elem
+      }
       function domContentLoaded() {
-        var extjs = document.createElement("script");
-        extjs.src = "https://cdn.jsdelivr.net/g/jquery@2.1.1,bootstrap@3.3.7";
-        document.body.appendChild(extjs);
-        var js = document.createElement("script");
-        js.src = "portal.js?v="+new Date().getTime();
-        document.body.appendChild(js);
+        _load_js("https://cdn.jsdelivr.net/g/jquery@2.1.1,bootstrap@3.3.7");
+        _load_js("portal.js?v="+new Date().getTime());
       }
       
       function jQueryOnLoad(){
@@ -331,6 +335,9 @@
             zoom();
             //wekan();
           });
+
+          _load_js("https://zammad.bewegung.jetzt/assets/form/form.js",
+                 "zammad_form_script").addEventListener('load', setupSupportButton);
       };
       if (window.addEventListener) window.addEventListener("DOMContentLoaded", domContentLoaded, false);
       else if (window.attachEvent) window.attachEvent("onDOMContentLoaded", domContentLoaded);

--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
         elem.src = path;
         elem.id = id;
         document.body.appendChild(elem);
-        return elem
+        return elem;
       }
       function domContentLoaded() {
         _load_js("https://cdn.jsdelivr.net/g/jquery@2.1.1,bootstrap@3.3.7");

--- a/portal.css
+++ b/portal.css
@@ -3,6 +3,8 @@ body {
   font-family:Rubik,sans-serif;
   font-style: normal;
   font-weight:400;
+  min-height: 100vh;
+  padding-bottom: 3em;
 }
 
 a:hover { text-decoration: none; }
@@ -79,7 +81,7 @@ li > ul {
 
 
 #btnSupport {
-  position: absolute;
+  position: fixed;
   bottom: 0;
   right: 3px;
   border-radius: 0;

--- a/portal.css
+++ b/portal.css
@@ -77,3 +77,10 @@ li > ul {
   margin-bottom: 0;
 }
 
+
+#btnSupport {
+  position: absolute;
+  bottom: 0;
+  right: 3px;
+  border-radius: 0;
+}

--- a/portal.js
+++ b/portal.js
@@ -296,3 +296,14 @@ function wekan() {
     li.appendChild(ul);
   }
 }
+
+function setupSupportButton() {
+  $('#btnSupport').ZammadForm({
+    messageTitle: 'IT-Support Anfrage',
+    messageSubmit: 'anfragen',
+    messageThankYou: 'Vielen Dank für Ihre Anfrage (#%s). Wir melden uns umgehend!',
+    showTitle: true,
+    modal: true,
+    attachmentSupport: true
+  });
+}


### PR DESCRIPTION
Nutz das Zammad-Formular-Feature um unten rechts eine Button einzufügen, welcher ein Formular öffnet in dem Menschen direkt den IT-Support konktaktieren 
können ohne den Umweg über die E-Mail gehen zu müssen.